### PR TITLE
Add Lego v4.9.0 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,12 @@
 # Python project configuration.
 
 [build-system]
-requires = ["poetry-core==1.2.2"]
+requires = ["poetry-core==1.3.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "lego-certbot"
-version = "0.1.0"
+version = "0.2.0"
 description = "Lego DNS-01 exec provider script for Certbot authenticator plugins"
 authors = ["Callum Dickinson <callum.dickinson.nz@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
* Don't hard-code the `_acme-challenge` subdomain
* Explicitly pass the root domain for the ACME challenge as `LEGOCERTBOT_DOMAIN` instead of inferring it from the `TXT` record name
* Add `--version` parameter
* Fix `poetry-core` version pin so that `pip install` will work
* Fix inconsistencies and typos in comments and `README.md`
* Add Tips and Tricks related to Lego v4.9.0's CNAME traversal change in `README.md`