### PR TITLE
Run CI using GitHub Actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: "pypy3.10"
+        python-version: "3.10"
         cache: "pip"
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "pypy3.10"
+        cache: "pip"
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Designed to be run using the [exec](https://go-acme.github.io/lego/dns/exec/) pr
 `lego-certbot` can be directly installed using `pip`.
 
 ```
-$ python3 -m pip install "lego-certbot @ https://github.com/Callum027/lego-certbot/archive/refs/tags/v0.2.0.zip"
+$ python3 -m pip install "lego-certbot @ https://github.com/Callum027/lego-certbot/archive/refs/tags/v0.3.0.zip"
 ```
 
 Available extras:
@@ -19,7 +19,7 @@ Available extras:
 The repository contains a fixed `requirements.txt` with known working package versions, and a virtual environment can be created based on that.
 
 ```
-$ git clone -b v0.2.0 https://github.com/Callum027/lego-certbot.git
+$ git clone -b v0.3.0 https://github.com/Callum027/lego-certbot.git
 $ cd lego-certbot
 $ python3 -m .venv
 $ source .venv/bin/activate
@@ -29,7 +29,7 @@ $ python3 -m pip install -r requirements.txt .
 Or, if you have Poetry installed, you can setup the virtual environment using `poetry install`.
 
 ```
-$ git clone -b v0.2.0 https://github.com/Callum027/lego-certbot.git
+$ git clone -b v0.3.0 https://github.com/Callum027/lego-certbot.git
 $ cd lego-certbot
 $ poetry install [--with=metaname]
 ```

--- a/lego_certbot.py
+++ b/lego_certbot.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from certbot.interfaces import DNSAuthenticator
 
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 def main() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "lego-certbot"
-version = "0.2.0"
+version = "0.3.0"
 description = "Lego DNS-01 exec provider script for Certbot authenticator plugins"
 authors = ["Callum Dickinson <callum.dickinson.nz@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
* Replace `pre-commit.ci` with GitHub Actions, as the former does not allow Internet access and automatic dependency updates are not required